### PR TITLE
ci(github): run rust checks only on rust changes

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -1,6 +1,22 @@
 name: Rust checks
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "rust-toolchain.toml"
+      - "rustfmt.toml"
+      - "clippy.toml"
+  push:
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "rust-toolchain.toml"
+      - "rustfmt.toml"
+      - "clippy.toml"
 
 jobs:
   clippy:

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -1,4 +1,4 @@
-name: Checks
+name: Rust checks
 
 on: [push, pull_request]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "1.66.1"
 components = ["miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.1"
+channel = "nightly"
 components = ["miri"]


### PR DESCRIPTION
Modify rust checks' workflow to only run when a source file related to rust or cargo is changed.