### PR TITLE
chore: simplify crates dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,69 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -463,8 +406,8 @@ name = "suugaku"
 version = "0.1.0"
 dependencies = [
  "clap",
- "num",
  "num-integer",
+ "num-traits",
  "proptest",
  "unordered-pair",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ description = "A command line interface to do math operations."
 
 [dependencies]
 clap = { version = "4.1.3", features = ["derive"] }
-num = "0.4.0"
 num-integer = "0.1.45"
+num-traits = "0.2.15"
 unordered-pair = "0.2.4"
 
 [dev-dependencies]

--- a/src/operations/find/sum/pairs/implementation.rs
+++ b/src/operations/find/sum/pairs/implementation.rs
@@ -3,10 +3,8 @@ use std::{
     hash::Hash,
 };
 
-use num::{
-    CheckedSub,
-    Integer,
-};
+use num_integer::Integer;
+use num_traits::CheckedSub;
 use unordered_pair::UnorderedPair;
 
 /// Finds pairs of numbers from a list that sum to the given target value.

--- a/src/operations/find/sum/pairs/implementation.rs
+++ b/src/operations/find/sum/pairs/implementation.rs
@@ -29,7 +29,7 @@ where
         // lower or higher than the range of numbers allowed for the bits size
         // of the target number
         if let Some(difference) = difference {
-            if numbers_set.contains(&difference) {
+            if difference != number && numbers_set.contains(&difference) {
                 let sum_pair = UnorderedPair(number, difference);
                 if !sum_pairs_found.contains(&sum_pair) {
                     sum_pairs.push(sum_pair);
@@ -80,6 +80,20 @@ mod tests {
         let numbers = &[1, 9, 5, 0, 20, -4, 12, 16, 7];
         let target = 12;
         let expected = &[(12, 0), (5, 7), (16, -4)];
+
+        check_sum_pairs!(numbers, target, expected);
+    }
+
+    /// Regression test:
+    ///
+    /// Each pair of numbers must be composed of two different numbers.
+    ///
+    /// Should return [] and not [(1,1)]
+    #[test]
+    fn pairs_cannot_have_duplicate_number() {
+        let numbers = &[1];
+        let target = 2;
+        let expected = &[];
 
         check_sum_pairs!(numbers, target, expected);
     }


### PR DESCRIPTION
Use only the crates with the features required without anything else.